### PR TITLE
lineageTree.pb update: new lineages (pango-designation release v1.14)

### DIFF
--- a/pangolin_data/__init__.py
+++ b/pangolin_data/__init__.py
@@ -1,3 +1,3 @@
 _program = "pangolin_data"
-__version__ = "1.13"
+__version__ = "1.14"
 


### PR DESCRIPTION
The tree is a severely pruned version of the UCSC tree (2022-08-19) re-rooted to lineage A with 50 randomly selected descendants per lineage.