### PR TITLE
lineageTree.pb update: new lineages (pango-designation release v1.16)

### DIFF
--- a/pangolin_data/__init__.py
+++ b/pangolin_data/__init__.py
@@ -1,3 +1,3 @@
 _program = "pangolin_data"
-__version__ = "1.15.1"
+__version__ = "1.16"
 


### PR DESCRIPTION
The tree is a severely pruned version of the UCSC tree (2022-11-01) re-rooted to lineage A with 50 randomly selected descendants per lineage.