### PR TITLE
lineageTree.pb update: new lineages (pango-designation release v1.18.1)

### DIFF
--- a/pangolin_data/__init__.py
+++ b/pangolin_data/__init__.py
@@ -1,3 +1,3 @@
 _program = "pangolin_data"
-__version__ = "1.18"
+__version__ = "1.18.1"
 


### PR DESCRIPTION
The tree is a severely pruned version of the UCSC tree (2023-02-15) re-rooted to lineage A with 50 randomly selected descendants per lineage.